### PR TITLE
Spell Bonus in Spell table

### DIFF
--- a/charactersheet/charactersheet/models/spell.js
+++ b/charactersheet/charactersheet/models/spell.js
@@ -39,7 +39,7 @@ function Spell() {
 	self.spellDamageLabel = ko.pureComputed(function() {
 		var charKey = CharacterManager.activeCharacter().key();
 		var spellBonus = SpellStats.findBy(charKey)[0].spellAttackBonus();
-		if( self.spellType() === 'Attack' && (spellBonus != null || spellBonus != '') ){
+		if( self.spellType() === 'Attack' && (spellBonus != null && spellBonus != '' && spellBonus != 0) ){
 			return (self.spellDmg() + ' [Spell Bonus: +' + spellBonus + ']');
 		}
 		else{

--- a/charactersheet/charactersheet/models/spell.js
+++ b/charactersheet/charactersheet/models/spell.js
@@ -36,6 +36,16 @@ function Spell() {
         'Self', 'Touch', '5 ft', '10 ft', '30 ft', '60 ft',
         '90 ft', '100 ft', '120 ft', '300 ft', '500 ft', '1 mile']);
 
+	self.spellDamageLabel = ko.pureComputed(function() {
+		var charKey = CharacterManager.activeCharacter().key();
+		var spellBonus = SpellStats.findBy(charKey)[0].spellAttackBonus();
+		if( self.spellType() === 'Attack' && (spellBonus != null || spellBonus != '') ){
+			return (self.spellDmg() + ' [Spell Bonus: +' + spellBonus + ']');
+		}
+		else{
+			return self.spellDmg();
+		}
+	});
     self.clear = function() {
         self.spellName('');
         self.spellType('');

--- a/charactersheet/charactersheet/models/spell.js
+++ b/charactersheet/charactersheet/models/spell.js
@@ -39,7 +39,7 @@ function Spell() {
 	self.spellDamageLabel = ko.pureComputed(function() {
 		var charKey = CharacterManager.activeCharacter().key();
 		var spellBonus = SpellStats.findBy(charKey)[0].spellAttackBonus();
-		if( self.spellType() === 'Attack' && (spellBonus != null && spellBonus != '' && spellBonus != 0) ){
+		if( self.spellType() === 'Attack' && spellBonus ){
 			return (self.spellDmg() + ' [Spell Bonus: +' + spellBonus + ']');
 		}
 		else{

--- a/charactersheet/charactersheet/models/spell_stats.js
+++ b/charactersheet/charactersheet/models/spell_stats.js
@@ -1,5 +1,9 @@
 "use strict";
 
+var SpellStatsSignaler = {
+	changed: new signals.Signal()
+};
+
 function SpellStats() {
 	var self = this;
   	self.ps = PersistenceService.register(SpellStats, self);

--- a/charactersheet/charactersheet/spells/app.js
+++ b/charactersheet/charactersheet/spells/app.js
@@ -21,7 +21,7 @@ function SpellbookViewModel() {
     self.selecteditem = ko.observable();
     self.blankSpell = ko.observable(new Spell());
     self.spellbook = ko.observableArray([]);
-
+	
     self.filter = ko.observable('');
     self.sort = ko.observable(self.sorts['spellName asc']);
 

--- a/charactersheet/charactersheet/spells/spells.tmpl.html
+++ b/charactersheet/charactersheet/spells/spells.tmpl.html
@@ -49,7 +49,7 @@
                href="#"
                data-toggle="modal"
                data-target="#viewSpell"></td>
-          <td class="hidden-sm hidden-xs" data-bind="text: spellDmg, click: $parent.editSpell"
+          <td class="hidden-sm hidden-xs" data-bind="text: spellDamageLabel, click: $parent.editSpell"
                href="#"
                data-toggle="modal"
                data-target="#viewSpell"></td>


### PR DESCRIPTION
If a bonus spell damage has been input in the Spell Stats module, the column in the Damage column in the Spells table will now show: __1d4 + 1 [Spell Bonus: +2]__
If a spell bonus has not been set, it will just read: __1d4 + 1__