### PR TITLE
Enabled spell slots edit modal.

### DIFF
--- a/charactersheet/charactersheet/templates/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/spell_slots.tmpl.html
@@ -17,16 +17,16 @@
 				<tr class="row" style="cursor:pointer;">
 					<td class="col-sm-1" data-bind="click: $parent.editSlot"
 					href="#"
-               		data-toggle="modal"
-               		data-target="#viewSlot">
+          data-toggle="modal"
+          data-target="#viewSlot">
 					  <span data-bind="css: color" class="form-control" style="margin-top:10px;padding:0px;width:25px;height:25px;border-radius:40px;">
 					  </span>
           			</td>
 					<td class="col-sm-1"
 					data-bind="click: $parent.editSlot"
 					href="#"
-               		data-toggle="modal"
-               		data-target="#viewSlot">
+          data-toggle="modal"
+          data-target="#viewSlot">
 					  <span class="text-center form-control" style="border:none;background:none;" data-bind="text: level">
 					  </span>
 					</td>
@@ -35,15 +35,15 @@
 						<span class="input-group-addon"
 						data-bind="click: $parent.editSlot"
 						href="#"
-               			data-toggle="modal"
-               			data-target="#viewSlot"> 
-               				<span data-bind="text: maxSpellSlots" ></span> - </span> 
+            data-toggle="modal"
+            data-target="#viewSlot"> 
+              <span data-bind="text: maxSpellSlots" ></span> - </span> 
 						<input type="number" min="0" class="form-control" data-bind="attr: { max: maxSpellSlots }, value: usedSpellSlots" />
 						<span class="input-group-addon" 
 						data-bind="click: $parent.editSlot" 
 						href="#"
-               			data-toggle="modal"
-               			data-target="#viewSlot"> = <span data-bind="text: spellSlots"></span> </span> 
+            data-toggle="modal"
+            data-target="#viewSlot"> = <span data-bind="text: spellSlots"></span> </span> 
 					</div>
 					</td>
 					<td> 

--- a/charactersheet/charactersheet/templates/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/spell_slots.tmpl.html
@@ -15,7 +15,8 @@
 			</thead>
 			<tbody data-bind="foreach: filteredAndSortedSlots">
 				<tr class="row" style="cursor:pointer;">
-					<td class="col-sm-1" data-bind="click: $parent.editSlot"	       href="#"
+					<td class="col-sm-1" data-bind="click: $parent.editSlot"
+					href="#"
                		data-toggle="modal"
                		data-target="#viewSlot">
 					  <span data-bind="css: color" class="form-control" style="margin-top:10px;padding:0px;width:25px;height:25px;border-radius:40px;">
@@ -31,8 +32,8 @@
 					</td>
 					<td class="col-sm-9"> 
 					<div class="input-group">
-						<span class="input-group-addon" 
-						data-bind="click: $parent.editSlot"     
+						<span class="input-group-addon"
+						data-bind="click: $parent.editSlot"
 						href="#"
                			data-toggle="modal"
                			data-target="#viewSlot"> 

--- a/charactersheet/charactersheet/templates/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/spell_slots.tmpl.html
@@ -14,14 +14,16 @@
 				</tr>
 			</thead>
 			<tbody data-bind="foreach: filteredAndSortedSlots">
-				<tr class="row">
+				<tr class="row" style="cursor:pointer;">
 					<td class="col-sm-1" data-bind="click: $parent.editSlot"	       href="#"
                		data-toggle="modal"
                		data-target="#viewSlot">
 					  <span data-bind="css: color" class="form-control" style="margin-top:10px;padding:0px;width:25px;height:25px;border-radius:40px;">
 					  </span>
           			</td>
-					<td class="col-sm-1" data-bind="click: $parent.editSlot"	       href="#"
+					<td class="col-sm-1"
+					data-bind="click: $parent.editSlot"
+					href="#"
                		data-toggle="modal"
                		data-target="#viewSlot">
 					  <span class="text-center form-control" style="border:none;background:none;" data-bind="text: level">
@@ -29,13 +31,15 @@
 					</td>
 					<td class="col-sm-9"> 
 					<div class="input-group">
-						<span class="input-group-addon" data-bind="click: $parent.editSlot"	       
+						<span class="input-group-addon" 
+						data-bind="click: $parent.editSlot"     
 						href="#"
                			data-toggle="modal"
                			data-target="#viewSlot"> 
                				<span data-bind="text: maxSpellSlots" ></span> - </span> 
 						<input type="number" min="0" class="form-control" data-bind="attr: { max: maxSpellSlots }, value: usedSpellSlots" />
-						<span class="input-group-addon" data-bind="click: $parent.editSlot"	   
+						<span class="input-group-addon" 
+						data-bind="click: $parent.editSlot" 
 						href="#"
                			data-toggle="modal"
                			data-target="#viewSlot"> = <span data-bind="text: spellSlots"></span> </span> 

--- a/charactersheet/charactersheet/templates/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/spell_slots.tmpl.html
@@ -15,22 +15,37 @@
 			</thead>
 			<tbody data-bind="foreach: filteredAndSortedSlots">
 				<tr class="row">
-					<td class="col-sm-1">
+					<td class="col-sm-1" data-bind="click: $parent.editSlot"	       href="#"
+               		data-toggle="modal"
+               		data-target="#viewSlot">
 					  <span data-bind="css: color" class="form-control" style="margin-top:10px;padding:0px;width:25px;height:25px;border-radius:40px;">
 					  </span>
-          </td>
-					<td class="col-sm-1">
+          			</td>
+					<td class="col-sm-1" data-bind="click: $parent.editSlot"	       href="#"
+               		data-toggle="modal"
+               		data-target="#viewSlot">
 					  <span class="text-center form-control" style="border:none;background:none;" data-bind="text: level">
 					  </span>
 					</td>
 					<td class="col-sm-9"> 
 					<div class="input-group">
-						<span class="input-group-addon"> <span data-bind="text: maxSpellSlots"></span> - </span> 
+						<span class="input-group-addon" data-bind="click: $parent.editSlot"	       
+						href="#"
+               			data-toggle="modal"
+               			data-target="#viewSlot"> 
+               				<span data-bind="text: maxSpellSlots" ></span> - </span> 
 						<input type="number" min="0" class="form-control" data-bind="attr: { max: maxSpellSlots }, value: usedSpellSlots" />
-						<span class="input-group-addon"> = <span data-bind="text: spellSlots"></span> </span> 
+						<span class="input-group-addon" data-bind="click: $parent.editSlot"	   
+						href="#"
+               			data-toggle="modal"
+               			data-target="#viewSlot"> = <span data-bind="text: spellSlots"></span> </span> 
 					</div>
 					</td>
-					<td> <a data-bind="click: $parent.removeSlot" href="#"> <i class="glyphicon glyphicon-remove"> </i> </a> </td>
+					<td> 
+						<a data-bind="click: $parent.removeSlot" href="#"> 
+							<i class="glyphicon glyphicon-remove"> </i> 
+						</a> 
+					</td>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
Spell slots can now be edited by clicking on the row. Fixing #303 