### PR TITLE
Fixes issue where profile module doesn't clean up after itself.

### DIFF
--- a/charactersheet/charactersheet/viewmodels/profile.js
+++ b/charactersheet/charactersheet/viewmodels/profile.js
@@ -4,7 +4,7 @@ function ProfileViewModel() {
 	var self = this;
 
 	self.profile = ko.observable(new Profile());
-    
+
 	self.init = function() {
 	};
 
@@ -25,13 +25,14 @@ function ProfileViewModel() {
 
 	self.unload = function() {
 		self.profile().save();
+		self.profile(new Profile());
 	};
-	
+
 	self.dataHasChanged = function() {
 		self.profile().save();
 		Notifications.profile.changed.dispatch();
 	};
-	
+
 	//Public Methods
 
 	self.clear = function() {

--- a/charactersheet/charactersheet/viewmodels/skills.js
+++ b/charactersheet/charactersheet/viewmodels/skills.js
@@ -62,25 +62,20 @@ function SkillsViewModel() {
     	}
 
     	//Subscriptions
-	    Notifications.abilityScores.changed.add(function() {
-	    	self.skills().forEach(function(e, i, _) {
-	    		e.updateValues();
-	    	})
-	    });
-	    Notifications.stats.changed.add(function() {
-	    	self.skills().forEach(function(e, i, _) {
-	    		e.updateValues();
-	    	})
-	    });
+	    Notifications.abilityScores.changed.add(self.dataHasChanged);
+	    Notifications.stats.changed.add(self.dataHasChanged);
         self.skills().forEach(function(e, i, _) {
             self.addNotifiers(e);
         })
     };
 
     self.unload = function() {
-    	$.each(self.skills(), function(_, e) {
+    	self.skills().forEach(function(e, i, _) {
     		e.save();
     	});
+    	self.skills([]);
+    	Notifications.abilityScores.changed.remove(self.dataHasChanged);
+    	Notifications.stats.changed.remove(self.dataHasChanged);
     };
 
 	/* UI Methods */
@@ -143,5 +138,11 @@ function SkillsViewModel() {
         skill.name.subscribe(savefn);
         skill.bonus.subscribe(savefn);
     }
+
+    self.dataHasChanged = function() {
+        self.skills().forEach(function(e, i, _) {
+            e.updateValues();
+        })
+    };
 };
 


### PR DESCRIPTION
Fixes #416, #418 

- Removes an unneeded jQuery $.each call.
- By resetting the profile object during `unload` the subscriptions
for that object will be GC'd.