### PR TITLE
Removed all satic lists from viewmodels and models.

### DIFF
--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -422,6 +422,7 @@
 <script src="utilities/character_manager.js" type="text/javascript"></script>
 <script src="utilities/notifications.js" type="text/javascript"></script>
 <script src="utilities/messenger.js" type="text/javascript"></script>
+<script src="utilities/fixtures.js" type="text/javascript"></script>
 
 <script type="text/javascript">
 	$(function(){

--- a/charactersheet/charactersheet/models/armor.js
+++ b/charactersheet/charactersheet/models/armor.js
@@ -19,10 +19,8 @@ function Armor() {
     self.armorClass = ko.observable('');
     self.armorStealth = ko.observable('');
     self.armorDescription = ko.observable('');
-    self.armorTypeOptions = ko.observableArray(
-        ['Light', 'Medium', 'Heavy', 'Shields']);
-    self.armorStealthOptions = ko.observableArray(
-        ['Advantage', 'Normal', 'Disadvantage']);
+    self.armorTypeOptions = ko.observableArray(Fixtures.armor.armorTypeOptions);
+    self.armorStealthOptions = ko.observableArray(Fixtures.armor.armorStealthOptions);
 
     self.proficiencyLabel = ko.pureComputed(function() {
         if (self.armorProficiency() === true) {

--- a/charactersheet/charactersheet/models/hit_dice_type.js
+++ b/charactersheet/charactersheet/models/hit_dice_type.js
@@ -7,8 +7,7 @@ function HitDiceType() {
 
 	self.characterId = ko.observable(null);
 	self.hitDiceType = ko.observable('');
-	self.hitDiceOptions = ko.observableArray(
-        ['D4', 'D6', 'D8', 'D10', 'D12', 'D20']);
+	self.hitDiceOptions = ko.observableArray(Fixtures.hitDiceType.hitDiceOptions);
 
     self.clear = function() {
         var values = new HitDiceType().exportValues();

--- a/charactersheet/charactersheet/models/magic_item.js
+++ b/charactersheet/charactersheet/models/magic_item.js
@@ -14,12 +14,8 @@ function MagicItem() {
     self.magicItemCharges = ko.observable(0);
     self.magicItemWeight = ko.observable(0);
     self.magicItemDescription = ko.observable('');
-    self.magicItemTypeOptions = ko.observableArray(
-        ['Armor', 'Sword', 'Rod', 'Ring', 'Staff',
-         'Wand', 'Potion', 'Wondrous Item']);
-    self.magicItemRarityOptions = ko.observableArray(
-        ['Uncommon', 'Common', 'Rare', 'Rarity Varies',
-         'Very Rare', 'Legendary']);
+    self.magicItemTypeOptions = ko.observableArray(Fixtures.magicItem.magicItemTypeOptions);
+    self.magicItemRarityOptions = ko.observableArray(Fixtures.magicItem.magicItemRarityOptions);
 
     self.chargesDisplay = ko.pureComputed(function(){
         if(self.magicItemMaxCharges() == 0){

--- a/charactersheet/charactersheet/models/spell.js
+++ b/charactersheet/charactersheet/models/spell.js
@@ -17,28 +17,13 @@ function Spell() {
     self.spellRange = ko.observable('');
     self.spellComponents = ko.observable('');
     self.spellDuration = ko.observable('');
-    self.spellTypeOptions = ko.observableArray(
-        ['Attack Roll', 'Savings Throw', 'Automatic']);
-    self.spellSaveAttrOptions = ko.observableArray(
-        ['Str', 'Dex', 'Con', 'Int', 'Wis', 'Cha']);
-    self.spellSchoolOptions = ko.observableArray([
-        'Abjuration', 'Cantrip', 'Conjuration',
-        'Divination', 'Enchantment', 'Evocation',
-        'Illusion', 'Necromancy', 'Transmutation']);
-    self.spellCastingTimeOptions = ko.observableArray([
-        '1 action', '1 bonus action', '1 reaction', '1 minute',
-        '10 minutes', '1 hour']);
-    self.spellDurationOptions = ko.observableArray([
-        'Instantaneous', '1 round', '1 min', '10 min', '1 hour', '8 hours',
-        '24 hours', '10 days', 'Concentration, 1 min',
-        'Concentration, 10 min', 'Concentration, 1 hour',
-        'Concentration, 24 hours', 'Special',
-        'Until dispelled']);
-    self.spellComponentsOptions = ko.observableArray([
-        'S', 'V', 'V, S', 'S, M', 'V, M', 'V, S, M']);
-    self.spellRangeOptions = ko.observableArray([
-        'Self', 'Touch', '5 ft', '10 ft', '30 ft', '60 ft',
-        '90 ft', '100 ft', '120 ft', '150 ft', '300 ft', '500 ft', '1 mile','Special']);
+    self.spellTypeOptions = ko.observableArray(Fixtures.spell.spellTypeOptions);
+    self.spellSaveAttrOptions = ko.observableArray(Fixtures.spell.spellSaveAttrOptions);
+    self.spellSchoolOptions = ko.observableArray(Fixtures.spell.spellSchoolOptions);
+    self.spellCastingTimeOptions = ko.observableArray(Fixtures.spell.spellCastingTimeOptions);
+    self.spellDurationOptions = ko.observableArray(Fixtures.spell.spellDurationOptions);
+    self.spellComponentsOptions = ko.observableArray(Fixtures.spell.spellComponentsOptions);
+    self.spellRangeOptions = ko.observableArray(Fixtures.spell.spellRangeOptions);
 
 	self.spellDamageLabel = ko.pureComputed(function() {
 		var charKey = CharacterManager.activeCharacter().key();

--- a/charactersheet/charactersheet/models/spell_stats.js
+++ b/charactersheet/charactersheet/models/spell_stats.js
@@ -9,8 +9,8 @@ function SpellStats() {
 	self.spellSaveDc = ko.observable(0);
 	self.spellAttackBonus = ko.observable(0);
 
-	self.spellcastingAbilityOptions = ko.observableArray([
-		'INT', 'WIS', 'CHA']);
+	self.spellcastingAbilityOptions = ko.observableArray(
+		Fixtures.spellStats.spellcastingAbilityOptions);
 
 	//Public Methods
 

--- a/charactersheet/charactersheet/models/weapon.js
+++ b/charactersheet/charactersheet/models/weapon.js
@@ -21,18 +21,17 @@ function Weapon() {
     self.weaponDescription = ko.observable('');
     self.weaponQuantity = ko.observable('');
     self.weaponProficiencyOptions = ko.observableArray(
-        ['Simple', 'Martial', 'Improvised', 'Nonlethal', 'Exotic']);
+        Fixtures.weapon.weaponProficiencyOptions);
     self.weaponHandednessOptions = ko.observableArray(
-        ['Light', 'One-Handed', 'Two-Handed']);
+        Fixtures.weapon.weaponHandednessOptions);
     self.weaponTypeOptions = ko.observableArray(
-        ['Melee', 'Ranged']);
+        Fixtures.weapon.weaponTypeOptions);
     self.weaponSizeOptions = ko.observableArray(
-        ['Small', 'Medium', 'Large']);
+        Fixtures.weapon.weaponSizeOptions);
     self.weaponPropertyOptions = ko.observableArray(
-        ['Ammunition', 'Finesse', 'Heavy', 'Light', 'Loading',
-         'Range', 'Reach', 'Special', 'Thrown', 'Versatile']);
+        Fixtures.weapon.weaponPropertyOptions);
     self.weaponDamageTypeOptions = ko.observableArray(
-         ['Bludgeoning', 'Piercing', 'Slashing']);
+        Fixtures.weapon.weaponDamageTypeOptions);
 
 
     self.updateValues = function() {

--- a/charactersheet/charactersheet/utilities/fixtures.js
+++ b/charactersheet/charactersheet/utilities/fixtures.js
@@ -1,0 +1,67 @@
+Fixtures = {
+	general : {
+		currencyDenominationList : [
+			'PP', 'GP', 'SP', 'EP', 'CP']
+	},
+	armor : {
+		armorTypeOptions : [
+			'Light', 'Medium', 'Heavy', 'Shields'],
+		armorStealthOptions : [
+			'Advantage', 'Normal', 'Disadvantage']
+	},
+	hitDiceType : {
+		hitDiceOptions : [
+		'D4', 'D6', 'D8', 'D10', 'D12', 'D20']
+	},
+	magicItem : {
+		magicItemTypeOptions : [
+			'Armor', 'Sword', 'Rod', 'Ring', 'Staff',
+         	'Wand', 'Potion', 'Wondrous Item'],
+     	magicItemRarityOptions : [
+     		'Uncommon', 'Common', 'Rare', 'Rarity Varies',
+         	'Very Rare', 'Legendary']
+	},
+	spell : {
+		spellTypeOptions : [
+			'Attack Roll', 'Savings Throw', 'Automatic'],
+		spellSaveAttrOptions : [
+			'Str', 'Dex', 'Con', 'Int', 'Wis', 'Cha'],
+		spellSchoolOptions : [
+        	'Abjuration', 'Cantrip', 'Conjuration',
+        	'Divination', 'Enchantment', 'Evocation',
+        	'Illusion', 'Necromancy', 'Transmutation'],
+        spellCastingTimeOptions : [
+        	'1 action', '1 bonus action', '1 reaction', '1 minute',
+        	'10 minutes', '1 hour'],
+        spellDurationOptions : [
+	        'Instantaneous', '1 round', '1 min', '10 min', '1 hour', '8 hours',
+	        '24 hours', '10 days', 'Concentration, 1 min',
+	        'Concentration, 10 min', 'Concentration, 1 hour',
+	        'Concentration, 24 hours', 'Special',
+	        'Until dispelled'],
+        spellComponentsOptions : [
+        	'S', 'V', 'V, S', 'S, M', 'V, M', 'V, S, M'],
+    	spellRangeOptions : [
+	        'Self', 'Touch', '5 ft', '10 ft', '30 ft', '60 ft',
+	        '90 ft', '100 ft', '120 ft', '150 ft', '300 ft', '500 ft', '1 mile','Special']
+	},
+	spellStats : {
+		spellcastingAbilityOptions: [
+		'INT', 'WIS', 'CHA']
+	},
+	weapon : {
+		weaponProficiencyOptions : [
+			'Simple', 'Martial', 'Improvised', 'Nonlethal', 'Exotic'],
+		weaponHandednessOptions : [
+			'Light', 'One-Handed', 'Two-Handed'],
+		weaponTypeOptions : [
+			'Melee', 'Ranged'],
+		weaponSizeOptions : [
+			'Small', 'Medium', 'Large'],
+		weaponPropertyOptions : [
+			'Ammunition', 'Finesse', 'Heavy', 'Light', 'Loading',
+         	'Range', 'Reach', 'Special', 'Thrown', 'Versatile'],
+     	weaponDamageTypeOptions : [
+     		'Bludgeoning', 'Piercing', 'Slashing']
+	}
+}

--- a/charactersheet/charactersheet/viewmodels/armor.js
+++ b/charactersheet/charactersheet/viewmodels/armor.js
@@ -6,8 +6,7 @@ function ArmorViewModel() {
     self.selecteditem = ko.observable();
     self.blankArmor = ko.observable(new Armor());
     self.armors = ko.observableArray([]);
-    self.currencyDenominationList = ko.observableArray([
-	    'PP', 'GP', 'SP', 'EP', 'CP']);
+    self.currencyDenominationList = ko.observableArray(Fixtures.general.currencyDenominationList);
 
     self.sorts = {
 	  'armorName asc': { field: 'armorName', direction: 'asc'},

--- a/charactersheet/charactersheet/viewmodels/items.js
+++ b/charactersheet/charactersheet/viewmodels/items.js
@@ -21,8 +21,7 @@ function ItemsViewModel() {
 	self.items = ko.observableArray([]);
 	self.blankItem = ko.observable(new Item());
 	self.selecteditem = ko.observable(new Item());
-	self.currencyDenominationList = ko.observableArray([
-		'PP', 'GP', 'SP', 'EP', 'CP']);
+	self.currencyDenominationList = ko.observableArray(Fixtures.general.currencyDenominationList);
 	self.sort = ko.observable(self.sorts['itemName asc']);
 	self.filter = ko.observable('');
 

--- a/charactersheet/charactersheet/viewmodels/weapons.js
+++ b/charactersheet/charactersheet/viewmodels/weapons.js
@@ -6,8 +6,7 @@ function WeaponsViewModel() {
     self.selecteditem = ko.observable();
     self.blankWeapon = ko.observable(new Weapon());
     self.weapons = ko.observableArray([]);
-	self.currencyDenominationList = ko.observableArray([
-		'PP', 'GP', 'SP', 'EP', 'CP']);
+	self.currencyDenominationList = ko.observableArray(Fixtures.general.currencyDenominationList);
 
     self.sorts = {
 	  'weaponName asc': { field: 'weaponName', direction: 'asc'},


### PR DESCRIPTION
New way to access static arrays and to create new static array.
If you need to access an existing static array, the format will be the following:

`
Fixtures.<model/viewmodel name>.<staticListName>
`

Example for getting weapon proficiency list: 
`
Fixtures.weapon.weaponProficiencyOptions
`

If you need to add new static list:
- If the model/viewmodel already exists, simply add it to that array within the main **_Fixtures_** arrays.
- If the model/viewmodel doesn't already exist, add a new one under the main **_Fixtures_** array.

Fixes #462 