### PR TITLE
Turns off tooltips on touch devices

### DIFF
--- a/charactersheet/bin/tooltip_bind.js
+++ b/charactersheet/bin/tooltip_bind.js
@@ -3,7 +3,12 @@
   'use strict';
 
   ko.bindingHandlers.tooltip = {
+    isTouch: function isTouchDevice(){
+        return true == ("ontouchstart" in window ||
+            window.DocumentTouch && document instanceof DocumentTouch);
+    },
     init: function(element, valueAccessor) {
+      if (ko.bindingHandlers.tooltip.isTouch()) return;
       var local = ko.utils.unwrapObservable(valueAccessor()),
           options = {};
 


### PR DESCRIPTION
### Summary of Changes

The tooltip binding now checks if the current device has touch enabled, and if so does not enable tooltips. We might want to be more clever with this in the future (i.e. allow the binding to override and use the tooltips if given an option, etc) but this should be enough for now.

### Issues Fixed

Fixes #627

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None

**Desired Reviewer:** @tanyxp @jkrooskos 

