### PR TITLE
Fixed hotkeys not working on <a> tags

### DIFF
--- a/charactersheet/charactersheet/services/hotkeys_service.js
+++ b/charactersheet/charactersheet/services/hotkeys_service.js
@@ -6,7 +6,8 @@
 
 var HotkeysService = {
     hotkeyHandler : function(data, event) {
-        var keypressIsInBody = event.target.tagName.toLowerCase() === 'body';
+        var keypressIsInBody = event.target.tagName.toLowerCase() !== 'input' &&
+            event.target.tagName.toLowerCase() !== 'textarea';
         if(keypressIsInBody){
             var metaKey = HotkeysService._determineMetakey(event);
 


### PR DESCRIPTION
### Summary of Changes
Hotkeys now work everywhere except **input** and **textareas**


### Issues Fixed
Fixes #677


### Changes Proposed (if any)
N/A



