### PR TITLE
Navbar now follows page margins

### DIFF
--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -17,24 +17,27 @@
 <body  data-bind="event: {keypress: HotkeysService.hotkeyHandler}">
 <nav class="navbar navbar-default navbar-static-top">
 <div class="container-fluid">
-	<div class="navbar-header">
-		<button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
-		  data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-		  <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span>
-		  <span class="icon-bar"></span><span class="icon-bar"></span>
-		</button>
-		<a href='/' class="navbar-brand">Adventurer's Codex
-		  <sup class="beta">Beta!</sup>
-		</a>
-	</div>
-	<div id="navbar" class="collapse navbar-collapse">
-		<ul class="nav navbar-nav">
-			<li><a href="//adventurerscodex.com/blog">Blog</a></li>
-			<li><a href="//tinyletter.com/adventurerscodex">Newsletter</a></li>
-		</ul>
-	</div>
-
-<!--/.nav-collapse -->
+  <div class="col-lg-1 visible-lg-block"></div>
+  <div class="col-lg-10 col-xs-12">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+        data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+        <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span>
+        <span class="icon-bar"></span><span class="icon-bar"></span>
+      </button>
+      <a href='/' class="navbar-brand">Adventurer's Codex
+        <sup class="beta">Beta!</sup>
+      </a>
+    </div>
+    <div id="navbar" class="collapse navbar-collapse">
+      <ul class="nav navbar-nav">
+        <li><a href="//adventurerscodex.com/blog">Blog</a></li>
+        <li><a href="//tinyletter.com/adventurerscodex">Newsletter</a></li>
+      </ul>
+    </div>
+  <!--/.nav-collapse -->
+  </div>
+  <div class="col-lg-1 visible-lg-block"></div>
 </div>
 </nav>
 <!-- ko if: ready -->


### PR DESCRIPTION
### Summary of Changes

When in large size, the nav bar margins follow the 1-10-1 style of the content. When smaller, it goes edge-to-edge like the content.

### Issues Fixed

Fixes #651

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)


#### Large
![](https://dl.dropboxusercontent.com/s/2exowb9vv3v2z2f/Screenshot%202016-06-30%2012.54.08.png?dl=0)

#### Small

![](https://dl.dropboxusercontent.com/s/irg97ebtbjrtulx/Screenshot%202016-06-30%2012.55.05.png?dl=0)
