### PR TITLE
 Changes Image-Content ratios on large displays to 3-9 over 4-8.

### DIFF
--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -142,10 +142,10 @@
   <div data-bind="template : { name: 'actions_toolbar.tmpl', templateUrl: 'templates', data: actionsToolbarViewModel }"></div>
 	<div role="tabpanel" class="tab-pane" id="stats" data-bind="with: statsTabViewModel, css: statsTabStatus">
 		<div class="row">
-			<div class="col-sm-4 hidden-xs">
+			<div class="col-sm-4 col-lg-3 hidden-xs">
 			  <img alt="A heart icon" src="/images/nested-hearts.svg">
       </div>
-			<div class="col-sm-8 col-padded">
+			<div class="col-sm-8 col-lg-9 col-padded">
 			  <div class="h3">
 			    Hit Points and Hit Dice<br />
 			    <small>Click on your Hit Points, when you level up,
@@ -200,10 +200,10 @@
 <!-- End Stats Tab -->
 	<div role="tabpanel" class="tab-pane" id="skills" data-bind="with: skillsTabViewModel, css: skillsTabStatus">
 		<div class="row">
-			<div class="col-sm-4 hidden-xs">
+			<div class="col-sm-4 col-lg-3 hidden-xs">
         <img alt="A sword in stone" src="/images/sword-spin.svg" />
 			</div>
-			<div class="col-sm-8 col-xs-12 col-padded">
+			<div class="col-sm-8 col-lg-9 col-xs-12 col-padded">
 			  <div class="h3">
 			    Daily Features<br />
 			    <small>These are features who's charges are restored whenever
@@ -236,10 +236,10 @@
 <!-- End Skills Tab -->
 	<div role="tabpanel" class="tab-pane" id="spells" data-bind="with: spellsTabViewModel, css: spellsTabStatus">
 		<div class="row">
-			<div class="col-sm-4 hidden-xs">
+			<div class="col-sm-4 col-lg-3 hidden-xs">
 				<img src="/images/enlightenment.svg" alt="Spells image"/>
 			</div>
-			<div class="col-sm-8 col-padded">
+			<div class="col-sm-8 col-lg-9 col-padded">
 				<div class="h3">
 					Spell Slots<br/>
 					<small>These slots are automatically refilled after a long rest. Click
@@ -269,10 +269,10 @@
 <!-- End Spells Tab -->
 	<div role="tabpanel" class="tab-pane" id="items" data-bind="with: equipmentTabViewModel, css: equipmentTabStatus">
 		<div class="row">
-			<div class="col-sm-4 hidden-xs">
+			<div class="col-sm-4 col-lg-3 hidden-xs">
         <img alt="A sword in stone" src="/images/spinning-sword.svg" />
 			</div>
-			<div class="col-sm-8 col-xs-12 col-padded">
+			<div class="col-sm-8 col-lg-9 col-xs-12 col-padded">
 			  <div class="h3">
 			    Weapons<br />
 			    <small>A weapon's To Hit bonus is automatically calculated based
@@ -283,7 +283,7 @@
 			</div>
     </div>
     <div class="row">
-			<div class="col-sm-8 col-xs-12 col-padded">
+			<div class="col-sm-8 col-lg-9 col-xs-12 col-padded">
 			  <div class="h3">
 			    Armor<br />
 			    <small>Your Armor doesn't automatically influence your
@@ -292,7 +292,7 @@
 				<div id="armors" data-bind="template: { name: 'armors.tmpl', templateUrl: 'templates', data: armorViewModel }">
 				</div>
 			</div>
-			<div class="col-sm-4 hidden-xs">
+			<div class="col-sm-4 col-lg-3 hidden-xs">
         <img alt="A sword in stone" src="/images/checked-shield.svg" />
 			</div>
 		</div>
@@ -300,7 +300,7 @@
 <!-- End Equipment Tab -->
 	<div role="tabpanel" class="tab-pane" id="inventory" data-bind="with: inventoryTabViewModel, css: inventoryTabStatus">
 		<div class="row">
-			<div class="col-sm-4 hidden-xs">
+			<div class="col-sm-4 col-lg-3 hidden-xs">
 				<img src="/images/shiny-purse.svg" alt="Inventory tab"/>
 			</div>
 			<div class="col-sm-8 col-padded">
@@ -313,7 +313,7 @@
 			</div>
 			</div>
 			<div class="row">
-				<div class="col-sm-8 col-padded">
+				<div class="col-sm-8 col-lg-9 col-padded">
 					<div class="h3">
 						Inventory &amp; Magic Items <br/>
 						<small>Don't hoard too much stuff; it's no fun to be encumbered.</small>

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -303,7 +303,7 @@
 			<div class="col-sm-4 col-lg-3 hidden-xs">
 				<img src="/images/shiny-purse.svg" alt="Inventory tab"/>
 			</div>
-			<div class="col-sm-8 col-padded">
+			<div class="col-sm-8 col-lg-9 col-padded">
 				<div class="h3">
 					Treasure<br/>
 					<small>“This should be in a museum!” -Indiana Jones</small>

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -321,7 +321,7 @@
 					<div data-bind="template: { name: 'magic_items.tmpl', templateUrl: 'templates', data: magicitemsViewModel }">
 					</div>
 				</div>
-				<div class="col-sm-4 hidden-xs">
+				<div class="col-sm-4 col-lg-3 hidden-xs">
 					<img src="/images/magic-lamp.svg" alt="Inventory tab"/>
 				</div>
 			</div>


### PR DESCRIPTION
### Summary of Changes

 Changes Image-Content ratios on large displays to 3-9 over 4-8. This prevents the content images from overwhelming the interface on large screens. Other sizes unaffected

### Issues Fixed

None Logged.

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

#### Large 

![](https://dl.dropboxusercontent.com/s/l3x0ui8sucdxesi/Screenshot%202016-06-30%2014.17.03.png?dl=0)

#### Other Sizes 

![](https://dl.dropboxusercontent.com/s/vpfqqf9elyuinh8/Screenshot%202016-06-30%2014.16.41.png?dl=0)