### PR TITLE
Fixes data export/import

### DIFF
--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -577,6 +577,8 @@
 <script src="utilities/view_model_utilities.js" type="text/javascript"></script>
 <!-- Components -->
 <script src="components/plus-minus.js" type="text/javascript"></script>
+<!-- Settings -->
+<script src="settings.js" type="text/javascript"></script>
 
 <!-- Init -->
 <script src="init.js" type="text/javascript"></script>

--- a/charactersheet/charactersheet/init.js
+++ b/charactersheet/charactersheet/init.js
@@ -3,6 +3,10 @@
  * and set up the environment.
  */
 var init = function(viewModel) {
+    //Always ignore values in this list when mapping.
+    ko.mapping.defaultOptions().ignore = Settings.mappingAlwaysIgnore;
+
+
     viewModel.init();
 
     //Set up event handlers.
@@ -26,28 +30,7 @@ var init = function(viewModel) {
             CharacterManager.activeCharacter().key());
     }
 
-    var dropboxConfigOptions = {
-        // Required. Called when a user selects an item in the Chooser.
-        success: function(files) {
-            WizardViewModel.importRemoteFile(files);
-        },
-        // Optional. Called when the user closes the dialog without selecting a file
-        // and does not include any parameters.
-        cancel: function() {},
-        // Optional. "preview" (default) is a preview link to the document for sharing,
-        // "direct" is an expiring link to download the contents of the file. For more
-        // information about link types, see Link types below.
-        linkType: 'direct', // or "direct"
-        // Optional. A value of false (default) limits selection to a single file, while
-        // true enables multiple file selection.
-        multiselect: false, // or true
-        // Optional. This is a list of file extensions. If specified, the user will
-        // only be able to select files with these extensions. You may also specify
-        // file types, such as "video" or "images" in the list. For more information,
-        // see File types below. By default, all extensions are allowed.
-        extensions: ['.json']
-    };
-
-    var button = Dropbox.createChooseButton(dropboxConfigOptions);
+    //Initialize dropbox integrations.
+    var button = Dropbox.createChooseButton(Settings.dropboxConfigOptions);
     document.getElementById('dropbox-container').appendChild(button);
 };

--- a/charactersheet/charactersheet/settings.js
+++ b/charactersheet/charactersheet/settings.js
@@ -1,0 +1,35 @@
+/**
+ * A global list of settings and static values.
+ */
+var Settings = {
+
+    /**
+     * A series of values to always ignore when mapping KO Objects.
+     */
+    mappingAlwaysIgnore: ['__id'],
+
+    /**
+     * A config object for dropbox integration.
+     */
+    dropboxConfigOptions: {
+        // Required. Called when a user selects an item in the Chooser.
+        success: function(files) {
+            WizardViewModel.importRemoteFile(files);
+        },
+        // Optional. Called when the user closes the dialog without selecting a file
+        // and does not include any parameters.
+        cancel: function() {},
+        // Optional. "preview" (default) is a preview link to the document for sharing,
+        // "direct" is an expiring link to download the contents of the file. For more
+        // information about link types, see Link types below.
+        linkType: 'direct', // or "direct"
+        // Optional. A value of false (default) limits selection to a single file, while
+        // true enables multiple file selection.
+        multiselect: false, // or true
+        // Optional. This is a list of file extensions. If specified, the user will
+        // only be able to select files with these extensions. You may also specify
+        // file types, such as "video" or "images" in the list. For more information,
+        // see File types below. By default, all extensions are allowed.
+        extensions: ['.json']
+    }
+};


### PR DESCRIPTION
### Summary of Changes

- Extracts settings into external file.
- Fixes issue where certain models would import Persistence IDs and break import process. This would cause the illusion of data loss but the complete exported file would still have the preserved data.

### Issues Fixed

Fixes #571 
Fixes #720 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None