### PR TITLE
Fixes failing builds to master when pushing new releases.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -28,3 +28,6 @@ rm -rf deploy*
 
 # Make CNAME File
 echo "$DOMAIN" > CNAME
+
+# Remove Travis file to stop failing master builds.
+rm .travis.yml


### PR DESCRIPTION
### Summary of Changes

Travis builds fail on `master` after new released because the tests are removed during the deploy process.

When a travis file is present, Travis builds and runs the tests. This removes the `.travis.yml` file when deploying the new releases.

### Issues Fixed

None logged.

### Changes Proposed (if any)

None 
