### PR TITLE
Fixes Stepper math issue

### DIFF
--- a/charactersheet/charactersheet/components/plus-minus.js
+++ b/charactersheet/charactersheet/components/plus-minus.js
@@ -19,14 +19,14 @@ function PlusMinusComponentViewModel(params) {
     self.min = params.min || ko.observable(0);
 
     self.increase = function() {
-        if (self.value() < parseInt(self.max())) {
-            self.value(self.value() + 1);
+        if (parseInt(self.value()) < parseInt(self.max())) {
+            self.value(parseInt(self.value()) + 1);
         }
     };
 
     self.decrease = function() {
-        if (self.value() > parseInt(self.min())) {
-            self.value(self.value() - 1);
+        if (parseInt(self.value()) > parseInt(self.min())) {
+            self.value(parseInt(self.value()) - 1);
         }
     };
 }


### PR DESCRIPTION
### Summary of Changes

When a value was manually entered for a damage/used value and then the stepper was called to incr/decr the value, it would be added as a string.

Turns out this was an issue with all of our steppers and it's fixed in the component.

### Issues Fixed

Fixes #734 

### Changes Proposed (if any)

None
